### PR TITLE
FINI-796: Update ESLint so it can parse ES2020 version of JavaScript/ECMAScript. 

### DIFF
--- a/ESLint/lombiq-base.js
+++ b/ESLint/lombiq-base.js
@@ -182,5 +182,10 @@ module.exports = {
         'strict': ['warn', 'safe'],
 
         'import/no-extraneous-dependencies': 'off',
-    }
+    },
+
+    // This is required for bleeding edge JS features like optional chaining (@babel/plugin-proposal-optional-chaining).
+    'parserOptions': {
+        'ecmaVersion': 2020
+    },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "gulp-rename": "2.0.0",
         "gulp-replace": "1.0.0",
         "gulp-sourcemaps": "2.6.5",
+        "gulp-style-inject": "^0.1.3",
         "gulp-watch": "5.0.1"
       }
     },
@@ -7002,6 +7003,55 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-style-inject": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-style-inject/-/gulp-style-inject-0.1.3.tgz",
+      "integrity": "sha512-8PAgZq8Rh9iPe81Bj7d0PKCyzIvchlJ6OwaADG5PKYnu5LB274mX8wj7wVW+wET+u7AiQ18kheqVNokedawQ9Q==",
+      "dev": true,
+      "dependencies": {
+        "plugin-error": "^1.0.1",
+        "through2": "0.6.3",
+        "vinyl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.2.10"
+      }
+    },
+    "node_modules/gulp-style-inject/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/gulp-style-inject/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/gulp-style-inject/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/gulp-style-inject/node_modules/through2": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+      "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "node_modules/gulp-watch": {
@@ -17788,6 +17838,53 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        }
+      }
+    },
+    "gulp-style-inject": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-style-inject/-/gulp-style-inject-0.1.3.tgz",
+      "integrity": "sha512-8PAgZq8Rh9iPe81Bj7d0PKCyzIvchlJ6OwaADG5PKYnu5LB274mX8wj7wVW+wET+u7AiQ18kheqVNokedawQ9Q==",
+      "dev": true,
+      "requires": {
+        "plugin-error": "^1.0.1",
+        "through2": "0.6.3",
+        "vinyl": "^2.2.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
+          "dev": true,
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@babel/preset-env": "^7.10.2",
         "autoprefixer": "9.7.4",
         "del": "5.1.0",
-        "eslint": "^7.2.0",
+        "eslint": "^7.5.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@babel/preset-env": "^7.10.2",
     "autoprefixer": "9.7.4",
     "del": "5.1.0",
-    "eslint": "^7.2.0",
+    "eslint": "^7.5.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-rename": "2.0.0",
     "gulp-replace": "1.0.0",
     "gulp-sourcemaps": "2.6.5",
+    "gulp-style-inject": "^0.1.3",
     "gulp-watch": "5.0.1"
   }
 }


### PR DESCRIPTION
Needed for the all-important [optional chaining (`?.`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish-coalescing (`??`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) operators.